### PR TITLE
Add option to vary spawn delays

### DIFF
--- a/Assets/00_Content/Scripts/Rounds/RoundController.cs
+++ b/Assets/00_Content/Scripts/Rounds/RoundController.cs
@@ -42,7 +42,7 @@ namespace Rounds {
 				? PlayerManager.Instance.NumPlayers - 1
 				: 0];
 
-			vikingController.SpawnDelay = difficulty.ScaledSpawnDelay(currentRound);
+			vikingController.SetSpawnSettings(difficulty.ScaledSpawnDelay(currentRound), difficulty.spawnDelayVariance);
 			vikingController.StatScaling = new VikingScaling(difficulty, currentRound);
 		}
 

--- a/Assets/00_Content/Scripts/Rounds/ScalingData.cs
+++ b/Assets/00_Content/Scripts/Rounds/ScalingData.cs
@@ -12,6 +12,9 @@ namespace Rounds {
 		[SerializeField, Min(0), Tooltip("Should be lower than InitialSpawnDelay")]
 		private float minimumSpawnDelay = 0f;
 
+		[SerializeField, Min(0), Tooltip("Excluded from initial and minimum spawnDelay")]
+		public float spawnDelayVariance;
+
 		[SerializeField, Min(0), Header("StartingMood")]
 		private float initialStartingMoodMultiplier = 1f;
 

--- a/Assets/00_Content/Scripts/Vikings/VikingController.cs
+++ b/Assets/00_Content/Scripts/Vikings/VikingController.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using Rounds;
 using UnityEngine;
+using Random = UnityEngine.Random;
 
 namespace Vikings {
 	public class VikingController : MonoBehaviour {
@@ -8,10 +9,11 @@ namespace Vikings {
 		[SerializeField] private Transform[] spawnPoints;
 
 		private Viking[] spawnedVikings;
+		private float spawnDelay = 1f;
+		private float spawnVariance;
 		private float spawnTimer;
 
 		public bool CanSpawn { get; set; } = true;
-		public float SpawnDelay { get; set; } = 1f;
 		public VikingScaling StatScaling { get; set; } = new VikingScaling();
 
 		private void Start() {
@@ -21,11 +23,11 @@ namespace Vikings {
 		private void Update() {
 			if (!CanSpawn) return;
 
-			spawnTimer = Mathf.Max(0, spawnTimer - Time.deltaTime);
+			spawnTimer -= Time.deltaTime;
 
 			if (spawnTimer <= 0) {
 				SpawnViking();
-				spawnTimer = SpawnDelay;
+				spawnTimer = spawnDelay + Random.Range(-spawnVariance, spawnVariance);
 			}
 		}
 
@@ -57,6 +59,11 @@ namespace Vikings {
 
 			spawnedVikings[index] = null;
 			Destroy(sender.gameObject);
+		}
+
+		public void SetSpawnSettings(float delay, float variance) {
+			spawnDelay = delay;
+			spawnVariance = variance;
 		}
 	}
 }


### PR DESCRIPTION
Closes #51 

**Description**  
You can add a variance to spawn delays in scaling data.

**List of changes**  
- Added spawndelay variance field to scaling data
- The Viking controller now changes the spawn delay between spawns
