### PR TITLE
Add required money per round

### DIFF
--- a/Assets/00_Content/Scripts/Rounds/RoundController.cs
+++ b/Assets/00_Content/Scripts/Rounds/RoundController.cs
@@ -14,6 +14,7 @@ namespace Rounds {
 		[SerializeField] private GameObject HUDPrefab;
 		[SerializeField, Tooltip("seconds/round")]
 		private int roundDuration;
+		[SerializeField] private int requiredMoney = 250;
 
 		private ScoreCard scoreCard;
 		private float roundTimer;
@@ -28,12 +29,12 @@ namespace Rounds {
 		public event Action OnRoundOver;
 
 		public float RoundTimer => roundTimer;
+		public int RequiredMoney => requiredMoney;
 
 		private void Start() {
 			scoreCard = Instantiate(scoreCardPrefab);
 			scoreCard.gameObject.SetActive(false);
 
-			Tavern.Instance.OnBankrupcy += HandleOnTavernBankrupt;
 			Tavern.Instance.OnDestroyed += HandleOnTavernDestroyed;
 			scoreCard.OnNextRound += HandleOnNextRound;
 
@@ -71,6 +72,13 @@ namespace Rounds {
 		}
 
 		private void ShowScoreCard() {
+			if (Tavern.Instance != null && Tavern.Instance.Money < requiredMoney) {
+				Debug.Log("Required money goal was not reached.");
+				// TODO: Maybe show the score card first?
+				GameOver();
+				//return;
+			}
+
 			scoreCard.UpdateScoreCard(currentRound);
 			scoreCard.gameObject.SetActive(true);
 
@@ -95,16 +103,19 @@ namespace Rounds {
 			SendNextDifficulty();
 			roundTimer = roundDuration;
 
+			if (Tavern.Instance != null)
+				Tavern.Instance.Money = Tavern.Instance.StartingMoney;
+
 			foreach (Table table in Table.AllTables) {
 				table.Repair();
 			}
 		}
 
-		private void HandleOnTavernDestroyed() {
-			throw new System.NotImplementedException();
+		private void GameOver() {
+			// TODO
 		}
 
-		private void HandleOnTavernBankrupt() {
+		private void HandleOnTavernDestroyed() {
 			throw new System.NotImplementedException();
 		}
 	}

--- a/Assets/00_Content/Scripts/Taverns/Tavern.cs
+++ b/Assets/00_Content/Scripts/Taverns/Tavern.cs
@@ -37,7 +37,8 @@ namespace Taverns {
 			set => money = Mathf.Round(Mathf.Clamp(value, 0, maxMoney));
 		}
 
-		void Start() {
+		protected override void Awake() {
+			base.Awake();
 			Health = startingHealth;
 			Money = startingMoney;
 		}

--- a/Assets/00_Content/Scripts/UI/HUD.cs
+++ b/Assets/00_Content/Scripts/UI/HUD.cs
@@ -1,8 +1,8 @@
-using UnityEngine;
-using UnityEngine.UI;
 using Rounds;
 using Taverns;
 using TMPro;
+using UnityEngine;
+using UnityEngine.UI;
 
 public class HUD : MonoBehaviour {
 	[SerializeField] private Slider tavernHealthSlider;
@@ -12,8 +12,8 @@ public class HUD : MonoBehaviour {
 	void Start() {
 		if (Tavern.Instance) {
 			tavernHealthSlider.maxValue = Tavern.Instance.MaxHealth;
-			tavernMoneyText.text = Tavern.Instance.StartingMoney.ToString();
-			tavernHealthSlider.value = Tavern.Instance.StartingHealth;
+			HandleOnMoneyChanges();
+			HandleOnHealthChanges();
 
 			Tavern.Instance.OnHealthChanges += HandleOnHealthChanges;
 			Tavern.Instance.OnMoneyChanges += HandleOnMoneyChanges;
@@ -33,6 +33,7 @@ public class HUD : MonoBehaviour {
 	}
 
 	private void HandleOnMoneyChanges() {
-		tavernMoneyText.text = Mathf.RoundToInt(Tavern.Instance.Money).ToString();
+		int requiredMoney = RoundController.Instance != null ? RoundController.Instance.RequiredMoney : 0;
+		tavernMoneyText.text = $"{Mathf.RoundToInt(Tavern.Instance.Money)}/{requiredMoney}";
 	}
 }


### PR DESCRIPTION
Closes #118 

**Additional context**  
Shown in the UI like this for now (current money/required money):
![image](https://user-images.githubusercontent.com/8546813/116258729-7c19a600-a775-11eb-84fe-456c59e512e7.png)

Currently nothing happens if you don't reach the goal. I'm thinking its better to implement together with #93.