### PR TITLE
Fix instrument range bug

### DIFF
--- a/Assets/00_Content/Scripts/Interactables/Instruments/Instrument.cs
+++ b/Assets/00_Content/Scripts/Interactables/Instruments/Instrument.cs
@@ -15,7 +15,7 @@ namespace Interactables.Instruments {
 
 		private bool isPlaying;
 		private GameObject usingPlayer;
-		private readonly List<Viking> vikingsInRange = new List<Viking>();
+		private List<Viking> vikingsInRange = new List<Viking>();
 
 		public DesireType DesireType => instrumentData.desireType;
 
@@ -40,6 +40,17 @@ namespace Interactables.Instruments {
 			Gizmos.DrawWireSphere(position, instrumentData.effectRadius);
 		}
 	#endif
+
+		public override void SetParent(Transform newParent) {
+			// NOTE: There seem to be some kind of undocumented behaviour where if you reparent the rigidbody,
+			// it re-enters all collisions without exiting them first. To mitigate this, clear the list of vikings
+			// before reparenting.
+			//
+			// This means that when reparenting, Enter will be called again for every object that was in the list. This
+			// may cause issues if you are doing things in Enter/Exit, so keep this behaviour in mind.
+			vikingsInRange.Clear();
+			base.SetParent(newParent);
+		}
 
 		public void Use(GameObject user) {
 			if (isPlaying) return;

--- a/Assets/00_Content/Scripts/Interactables/PickUp.cs
+++ b/Assets/00_Content/Scripts/Interactables/PickUp.cs
@@ -45,9 +45,13 @@ namespace Interactables {
 				RoundController.Instance.OnRoundOver -= Respawn;
 		}
 
+		public virtual void SetParent(Transform newParent) {
+			transform.SetParent(newParent);
+		}
+
 		//Drop item on floor or snap to slot if close
 		public void DropItem() {
-			transform.SetParent(null);
+			SetParent(null);
 			if (rigidbody != null)
 				rigidbody.isKinematic = false;
 
@@ -61,7 +65,7 @@ namespace Interactables {
 
 		public void PickUpItem(Transform playerGrabTransform) {
 			transform.rotation = Quaternion.identity;
-			transform.SetParent(playerGrabTransform);
+			SetParent(playerGrabTransform);
 			if (rigidbody != null)
 				rigidbody.isKinematic = true;
 


### PR DESCRIPTION
Closes #168 

**Description**  
There seem to be some kind of undocumented behaviour where if you reparent the rigidbody, it re-enters all collisions without exiting them first. To mitigate this, I clear the list of vikings before reparenting.

I also fixed an issue where vikings are added multiple times to the list.