### PR TITLE
Disable given item instead of destroy and respawn

### DIFF
--- a/Assets/00_Content/Scripts/Player/PlayerPickUp.cs
+++ b/Assets/00_Content/Scripts/Player/PlayerPickUp.cs
@@ -1,6 +1,5 @@
 using System;
 using Interactables;
-using Rounds;
 using UnityEngine;
 
 namespace Player {
@@ -74,13 +73,6 @@ namespace Player {
 
 		public bool CanPickUp(PickUp pickUp) {
 			return pickedUpItem == null;
-		}
-
-		public void ConsumeItem() {
-			if (pickedUpItem == null) return;
-
-			Destroy(pickedUpItem.gameObject);
-			pickedUpItem = null;
 		}
 
 		public void RespawnHeldItem() {

--- a/Assets/00_Content/Scripts/Rounds/RoundController.cs
+++ b/Assets/00_Content/Scripts/Rounds/RoundController.cs
@@ -34,6 +34,7 @@ namespace Rounds {
 
 		public float RoundTimer => roundTimer;
 		public int RequiredMoney => requiredMoney;
+		public bool IsRoundActive => isRoundActive;
 
 		private void Start() {
 			scoreCard = Instantiate(scoreCardPrefab);

--- a/Assets/00_Content/Scripts/Vikings/States/DesiringVikingState.cs
+++ b/Assets/00_Content/Scripts/Vikings/States/DesiringVikingState.cs
@@ -105,16 +105,22 @@ namespace Vikings.States {
 
 		private VikingState DesireFulfilled() {
 			DesireData desire = viking.CurrentDesire;
-			if (desire.isMaterialDesire) {
-				fulfillingPlayer.GetComponentInChildren<PlayerPickUp>().ConsumeItem();
-				fulfillingPlayer.GetComponentInChildren<PlayerMovement>().CanMove = true;
-			}
 
 			viking.CurrentDesireIndex++;
 			viking.MoodWhenDesireFulfilled.Add(viking.Stats.Mood);
 			AudioManager.PlayEffectSafe(SoundEffect.Viking_DesireFilledMan);
 
-			return new SatisfiedVikingState(viking, desire.type);
+			if (desire.isMaterialDesire) {
+				PlayerPickUp playerPickUp = fulfillingPlayer.GetComponentInChildren<PlayerPickUp>();
+				PickUp givenItem = playerPickUp.PickedUpItem;
+				givenItem.gameObject.SetActive(false);
+				playerPickUp.DropItem();
+
+				fulfillingPlayer.GetComponentInChildren<PlayerMovement>().CanMove = true;
+				return new SatisfiedVikingState(viking, givenItem);
+			}
+
+			return new SatisfiedVikingState(viking);
 		}
 	}
 }

--- a/Assets/00_Content/Scripts/Vikings/States/SatisfiedVikingState.cs
+++ b/Assets/00_Content/Scripts/Vikings/States/SatisfiedVikingState.cs
@@ -1,6 +1,7 @@
 ﻿using System.Linq;
 using Interactables;
 using Interactables.Beers;
+using Rounds;
 using UnityEngine;
 using Utilities;
 
@@ -45,8 +46,10 @@ namespace Vikings.States {
 				Vector3 throwDirection = -viking.transform.forward;
 				throwDirection.y = 0.7f;
 
-				givenItem.GetComponent<Rigidbody>().velocity = MathX.RandomDirectionInCone(throwDirection, viking.tankardThrowConeHalfAngle) *
-					viking.tankardThrowStrength;
+				if (RoundController.Instance != null && !RoundController.Instance.IsRoundActive)
+					givenItem.Respawn();
+				else
+					givenItem.GetComponent<Rigidbody>().velocity = MathX.RandomDirectionInCone(throwDirection, viking.tankardThrowConeHalfAngle) * viking.tankardThrowStrength;
 			}
 		}
 

--- a/Assets/00_Content/Scripts/Vikings/States/SatisfiedVikingState.cs
+++ b/Assets/00_Content/Scripts/Vikings/States/SatisfiedVikingState.cs
@@ -1,4 +1,6 @@
 ﻿using System.Linq;
+using Interactables;
+using Interactables.Beers;
 using UnityEngine;
 using Utilities;
 
@@ -12,12 +14,14 @@ namespace Vikings.States {
 		private int coinsToDrop;
 		private float dropTimer;
 
-		private DesireType previousDesire;
+		private PickUp givenItem;
 
 		private bool IsDroppingCoins => coinsToDrop > 0;
 
-		public SatisfiedVikingState(Viking viking, DesireType previousDesire) : base(viking) {
-			this.previousDesire = previousDesire;
+		public SatisfiedVikingState(Viking viking) : base(viking) { }
+
+		public SatisfiedVikingState(Viking viking, PickUp givenItem) : this(viking) {
+			this.givenItem = givenItem;
 		}
 
 		public override VikingState Enter() {
@@ -31,15 +35,17 @@ namespace Vikings.States {
 		}
 
 		public override void Exit() {
-			if (previousDesire == DesireType.Beer) {
-				Rigidbody tankardBody = Object.Instantiate(viking.tankardPrefab,
-				                                           viking.transform.position + new Vector3(0, 2.5f, 0),
-				                                           Quaternion.identity).GetComponent<Rigidbody>();
+			if (givenItem != null) {
+				if (givenItem is Tankard tankard)
+					tankard.IsFull = false;
+
+				givenItem.gameObject.SetActive(true);
+				givenItem.transform.position = viking.transform.position + new Vector3(0, 2.5f, 0);
 
 				Vector3 throwDirection = -viking.transform.forward;
 				throwDirection.y = 0.7f;
 
-				tankardBody.velocity = MathX.RandomDirectionInCone(throwDirection, viking.tankardThrowConeHalfAngle) *
+				givenItem.GetComponent<Rigidbody>().velocity = MathX.RandomDirectionInCone(throwDirection, viking.tankardThrowConeHalfAngle) *
 					viking.tankardThrowStrength;
 			}
 		}


### PR DESCRIPTION
Fixes #185 

**Description**  
This prevents the tankards from floating between rounds.

**List of changes**  
- No longer destroys and instantiates the tankard.
- Now throws away all items given to a desiring viking
