### PR TITLE
Final commit, whenever all tables are destroyed the game is lost

### DIFF
--- a/Assets/00_Content/Scenes/Game.unity
+++ b/Assets/00_Content/Scenes/Game.unity
@@ -5389,6 +5389,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: Tavern
       objectReference: {fileID: 0}
+    - target: {fileID: 7468624116003583018, guid: f69a5d19fccb9d0429dc70d49e09a553, type: 3}
+      propertyPath: startingMoney
+      value: 0
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: f69a5d19fccb9d0429dc70d49e09a553, type: 3}
 --- !u!1001 &1602984954

--- a/Assets/00_Content/Scripts/Interactables/Table.cs
+++ b/Assets/00_Content/Scripts/Interactables/Table.cs
@@ -10,6 +10,7 @@ using Vikings;
 namespace Interactables {
 	public class Table : Interactable {
 		public static List<Table> AllTables { get; } = new List<Table>();
+		public static event Action OnTablesDestroyed;
 
 		private float health;
 		private bool isRepairing;
@@ -120,7 +121,6 @@ namespace Interactables {
 					closest = chair;
 				}
 			}
-
 			return closest != null;
 		}
 
@@ -131,10 +131,9 @@ namespace Interactables {
 			if (IsDestroyed) {
 				GetComponentInChildren<MeshRenderer>().enabled = false;
 
-				if (Tavern.Instance != null)
-					Tavern.Instance.TakesDamage(1);
-
 				Destroyed?.Invoke();
+
+				if (IsTablesDestroyed()) OnTablesDestroyed?.Invoke();
 			}
 		}
 
@@ -144,6 +143,13 @@ namespace Interactables {
 
 			GetComponentInChildren<MeshRenderer>().enabled = true;
 			Repaired?.Invoke();
+		}
+
+		private bool IsTablesDestroyed() {
+			foreach (Table table in AllTables) {
+				if (!table.IsDestroyed) return false;
+			}
+			return true;
 		}
 	}
 }

--- a/Assets/00_Content/Scripts/Rounds/RoundController.cs
+++ b/Assets/00_Content/Scripts/Rounds/RoundController.cs
@@ -42,8 +42,8 @@ namespace Rounds {
 			gameOverPanel = Instantiate(gameOverPanelPrefab);
 			gameOverPanel.gameObject.SetActive(false);
 
-			Tavern.Instance.OnDestroyed += HandleOnTavernDestroyed;
 			scoreCard.OnNextRound += HandleOnNextRound;
+			Table.OnTablesDestroyed += HandleOnTablesDestroyed;
 
 			roundTimer = roundDuration;
 
@@ -131,7 +131,7 @@ namespace Rounds {
 			}
 		}
 
-		private void HandleOnTavernDestroyed() {
+		private void HandleOnTablesDestroyed() {
 			isRoundActive = false;
 			OnRoundOver?.Invoke();
 			DisableGamePlay();

--- a/Assets/00_Content/Scripts/Taverns/Tavern.cs
+++ b/Assets/00_Content/Scripts/Taverns/Tavern.cs
@@ -63,23 +63,5 @@ namespace Taverns {
 				OnBankrupcy?.Invoke();
 			}
 		}
-
-		public void TakesDamage(float damage) {
-			if (IsDestroyed) return;
-
-			Health -= damage;
-			OnHealthChanges?.Invoke();
-
-			if (IsDestroyed) {
-				Debug.Log("Tavern says: Game over, your tavern is destroyed!");
-
-				OnDestroyed?.Invoke();
-			}
-		}
-
-		public void RepairsDamage(float repair) {
-			Health += repair;
-			OnHealthChanges?.Invoke();
-		}
 	}
 }


### PR DESCRIPTION
I have some more variables & events that needs to be removed, but I'm waiting to do this until all three of these pull requests have been merged. So that I don't need to do the same job twice.

Closes 90

**Description**  
Table holds a function that runs whenever a table is destroyed, if the function is unable to find a table that isn't destroyed it will invoke static event "OnTablesDestroyed". RoundController subscribes to this event with the function "HandleOnTablesDestroyed()" that handles "game over".
