### PR TITLE
Mood boost on fulfillments

### DIFF
--- a/Assets/00_Content/ScriptableObjects/Vikings/NormalViking.asset
+++ b/Assets/00_Content/ScriptableObjects/Vikings/NormalViking.asset
@@ -14,6 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   startMood: 100
   moodDeclineRate: 1.5
+  moodBoostDesireFulfilled: 30
   impatientMoodThreshold: 60
   randomDesires: 1
   desires:

--- a/Assets/00_Content/Scripts/Vikings/States/DesiringVikingState.cs
+++ b/Assets/00_Content/Scripts/Vikings/States/DesiringVikingState.cs
@@ -28,7 +28,7 @@ namespace Vikings.States {
 			float remappedMood = MathX.RemapClamped(viking.Stats.Mood, viking.Data.brawlMoodThreshold, viking.Stats.StartMood, 0, 1);
 			viking.desireVisualiser.SetDesireColor(remappedMood);
 			viking.desireVisualiser.SetTweenSpeed(remappedMood);
-			
+
 			if (hasActiveFulfillment) {
 				fulfillmentTimer += Time.deltaTime;
 
@@ -90,6 +90,7 @@ namespace Vikings.States {
 
 			if (viking.CurrentDesire.isOrder && !isOrderGiven) {
 				SpawnOrderTicket();
+				viking.Stats.BoostMood(viking.Data.moodBoostDesireFulfilled);
 				return this;
 			}
 
@@ -119,6 +120,7 @@ namespace Vikings.States {
 
 			viking.CurrentDesireIndex++;
 			viking.MoodWhenDesireFulfilled.Add(viking.Stats.Mood);
+			viking.Stats.BoostMood(viking.Data.moodBoostDesireFulfilled);
 			AudioManager.PlayEffectSafe(SoundEffect.Viking_DesireFilledMan);
 
 			if (desire.isMaterialDesire) {
@@ -135,7 +137,6 @@ namespace Vikings.States {
 		}
 
 		private void SpawnOrderTicket() {
-			viking.desireVisualiser.HideDesire();
 			viking.desireVisualiser.ShowNewDesire(viking.CurrentDesire.visualisationAfterPrefab);
 			Object.Instantiate(viking.kitchenTicketPrefab, viking.transform.position + new Vector3(0, 2, 0), Quaternion.identity);
 			isOrderGiven = true;

--- a/Assets/00_Content/Scripts/Vikings/States/SatisfiedVikingState.cs
+++ b/Assets/00_Content/Scripts/Vikings/States/SatisfiedVikingState.cs
@@ -1,8 +1,6 @@
 using System.Linq;
 using Interactables;
 using Interactables.Beers;
-using Interactables.Kitchens;
-using Rounds;
 using UnityEngine;
 using Utilities;
 
@@ -43,14 +41,14 @@ namespace Vikings.States {
 			if (givenItem != null) {
 				if (givenItem is Tankard tankard)
 					tankard.IsFull = false;
-				
-				if (satisfiedDesire.shouldThrowItem) { 
+
+				if (satisfiedDesire.shouldThrowItem) {
 					givenItem.gameObject.SetActive(true);
 					givenItem.transform.position = viking.transform.position + new Vector3(0, 2.5f, 0);
 
 					Vector3 throwDirection = -viking.transform.forward;
 					throwDirection.y = 0.7f;
-          
+
           givenItem.GetComponent<Rigidbody>().velocity = MathX.RandomDirectionInCone(throwDirection, viking.tankardThrowConeHalfAngle) * viking.tankardThrowStrength;
 				}
 			}
@@ -95,10 +93,8 @@ namespace Vikings.States {
 			if (dropTimer <= 0) {
 				DropCoin();
 
-				if (coinsToDrop <= 0) {
-					viking.Stats.Reset();
+				if (coinsToDrop <= 0)
 					return SelectNextState();
-				}
 
 				dropTimer = DropDelay;
 			}

--- a/Assets/00_Content/Scripts/Vikings/VikingData.cs
+++ b/Assets/00_Content/Scripts/Vikings/VikingData.cs
@@ -10,6 +10,9 @@ namespace Vikings {
 		[Tooltip("Mood/s")]
 		public float moodDeclineRate;
 
+		[Min(0), Tooltip("How much mood does a viking receive when a desire is fulfilled")]
+		public float moodBoostDesireFulfilled;
+
 		[Tooltip("Threshold for when the viking just takes a table on its own, without waiting for a player to lead them.")]
 		public float impatientMoodThreshold = 45;
 

--- a/Assets/00_Content/Scripts/Vikings/VikingStats.cs
+++ b/Assets/00_Content/Scripts/Vikings/VikingStats.cs
@@ -39,6 +39,10 @@ namespace Vikings {
 			RecalculateModifier(modifier.statType);
 		}
 
+		public void BoostMood(float boost) {
+			Mood = Mathf.Min(StartMood, Mood + boost);
+		}
+
 		public void TakeMoodDamage(float moodDamage) {
 			Mood -= moodDamage;
 		}


### PR DESCRIPTION
Closes #260 

**Description**  
Instead of resetting mood to start, it now increases it by a value.

**List of changes**  
- Added ability to boost mood up to start mood.
- Boosts mood on order taken as well as food given.
