### PR TITLE
Throw coins cone

### DIFF
--- a/Assets/00_Content/Scripts/Interactables/Coin.cs
+++ b/Assets/00_Content/Scripts/Interactables/Coin.cs
@@ -1,9 +1,11 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using Audio;
 using Extensions;
 using Taverns;
 using UnityEngine;
 using World;
+using Random = UnityEngine.Random;
 
 namespace Interactables {
 	[RequireComponent(typeof(Rigidbody))]
@@ -20,6 +22,7 @@ namespace Interactables {
 		[SerializeField] private float hitSoundVelocityThreshold = 2f;
 
 		private bool isDisplay;
+		private Rigidbody rb;
 
 		/// <summary>
 		/// Is the coin only for display - meaning it can't be picked up and has no physics?
@@ -30,8 +33,7 @@ namespace Interactables {
 				if (isDisplay == value)
 					return;
 
-				Rigidbody body = GetComponent<Rigidbody>();
-				body.isKinematic = value;
+				rb.isKinematic = value;
 				if (value)
 					AllCoins.SwapRemove(this);
 				else
@@ -41,13 +43,13 @@ namespace Interactables {
 			}
 		}
 
-		private void Start() {
-			if (isDisplay) {
-				AllCoins.SwapRemove(this);
-				return;
-			}
+		private void Awake() {
+			rb = GetComponent<Rigidbody>();
+		}
 
-			RandomThrow();
+		private void Start() {
+			if (isDisplay)
+				AllCoins.SwapRemove(this);
 		}
 
 		private void OnEnable() {
@@ -85,16 +87,18 @@ namespace Interactables {
 		}
 
 		public void RandomThrow() {
-			Rigidbody rb = GetComponent<Rigidbody>();
-
 			float x = Mathf.Sin(Random.Range(0, Mathf.PI * 2));
 			float z = Mathf.Cos(Random.Range(0, Mathf.PI * 2));
 
-			Vector3 direction = new Vector3(x, 0, z).normalized * Random.Range(minSpawnVelocity, maxSpawnVelocity);
-			direction.y = upVelocity;
+			ThrowInDirection(new Vector3(x, 0, z).normalized);
+		}
 
-			rb.AddForce(direction, ForceMode.Impulse);
-			rb.AddRelativeTorque(direction, ForceMode.Impulse);
+		public void ThrowInDirection(Vector3 direction) {
+			Vector3 force = direction * Random.Range(minSpawnVelocity, maxSpawnVelocity);
+			force.y = Math.Max(force.y, upVelocity);
+
+			rb.AddForce(force, ForceMode.Impulse);
+			rb.AddRelativeTorque(force, ForceMode.Impulse);
 		}
 	}
 }

--- a/Assets/00_Content/Scripts/Utilities/MathX.cs
+++ b/Assets/00_Content/Scripts/Utilities/MathX.cs
@@ -69,9 +69,24 @@ namespace Utilities {
 		/// <param name="direction">The direction of the cone.</param>
 		/// <param name="halfAngle">Half the angle of the cone measured in degrees.</param>
 		public static Vector3 RandomDirectionInCone(Vector3 direction, float halfAngle) {
-			float radius = Mathf.Tan(halfAngle * Mathf.Deg2Rad);
+			float radius = Mathf.Sin(halfAngle * Mathf.Deg2Rad);
 			Vector2 pointInCircle = Random.insideUnitCircle * radius;
 			return (Quaternion.LookRotation(direction) * new Vector3(pointInCircle.x, pointInCircle.y, 1f)).normalized;
+		}
+
+		/// <summary>
+		/// Get a random direction within a 180° wide quarter sphere.
+		/// </summary>
+		public static Vector3 RandomDirectionInQuarterSphere(Vector3 forward, Vector3 up) {
+			Vector3 pointInSphere = Random.onUnitSphere;
+
+			if (Vector3.Dot(pointInSphere, Vector3.forward) < 0)
+				pointInSphere.z = -pointInSphere.z;
+
+			if (Vector3.Dot(pointInSphere, Vector3.up) < 0)
+				pointInSphere.y = -pointInSphere.y;
+
+			return Quaternion.LookRotation(forward, up) * pointInSphere;
 		}
 
 		public static Vector2 Rotate2D(Vector2 vector, float angle) {

--- a/Assets/00_Content/Scripts/Vikings/States/SatisfiedVikingState.cs
+++ b/Assets/00_Content/Scripts/Vikings/States/SatisfiedVikingState.cs
@@ -49,7 +49,7 @@ namespace Vikings.States {
 					Vector3 throwDirection = -viking.transform.forward;
 					throwDirection.y = 0.7f;
 
-          givenItem.GetComponent<Rigidbody>().velocity = MathX.RandomDirectionInCone(throwDirection, viking.tankardThrowConeHalfAngle) * viking.tankardThrowStrength;
+          givenItem.GetComponent<Rigidbody>().velocity = MathX.RandomDirectionInCone(throwDirection, viking.itemThrowConeHalfAngle) * viking.throwStrength;
 				}
 			}
 		}
@@ -103,7 +103,8 @@ namespace Vikings.States {
 		}
 
 		private void DropCoin() {
-			Object.Instantiate(viking.coinPrefab, viking.transform.position + new Vector3(0, 2, 0), Quaternion.identity);
+			Coin coin = Object.Instantiate(viking.coinPrefab, viking.transform.position + new Vector3(0, 2, 0), Quaternion.identity);
+			coin.ThrowInDirection(MathX.RandomDirectionInQuarterSphere(-viking.transform.forward, Vector3.up));
 			coinsToDrop--;
 		}
 

--- a/Assets/00_Content/Scripts/Vikings/Viking.cs
+++ b/Assets/00_Content/Scripts/Vikings/Viking.cs
@@ -25,7 +25,6 @@ namespace Vikings {
 		[SerializeField] private VikingData vikingData;
 		[SerializeField] public GameObject beingSeatedHighlightPrefab;
 		[SerializeField] public Coin coinPrefab;
-		[SerializeField] public Tankard tankardPrefab;
 		[SerializeField] public KitchenTicket kitchenTicketPrefab;
 		[SerializeField] public DesireVisualiser desireVisualiser;
 		[SerializeField] public ProgressBar progressBar;
@@ -34,8 +33,8 @@ namespace Vikings {
 		[SerializeField] public Material brawlingMaterial;
 
 		[Space]
-		[SerializeField] public float tankardThrowConeHalfAngle = 15f;
-		[SerializeField] public float tankardThrowStrength = 5f;
+		[SerializeField] public float itemThrowConeHalfAngle = 15f;
+		[SerializeField] public float throwStrength = 5f;
 
 		private bool hasStartedAttackingPlayer;
 		private VikingState state;


### PR DESCRIPTION
Closes #256 

**Description**  
Vikings now throws coins behind themselves in a 180° "cone".

**List of changes**  
- Added random direction in quartersphere.
- Coins no longer throws themselves on start.
- Coints can now be thrown in a direction