### PR TITLE
Change player velocity movement

### DIFF
--- a/Assets/00_Content/PhysicMaterials.meta
+++ b/Assets/00_Content/PhysicMaterials.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c6bc64f514f23204287228f7da9d1f29
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/00_Content/PhysicMaterials/NoFriction.physicMaterial
+++ b/Assets/00_Content/PhysicMaterials/NoFriction.physicMaterial
@@ -1,0 +1,14 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!134 &13400000
+PhysicMaterial:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: NoFriction
+  dynamicFriction: 0
+  staticFriction: 0
+  bounciness: 0
+  frictionCombine: 1
+  bounceCombine: 1

--- a/Assets/00_Content/PhysicMaterials/NoFriction.physicMaterial.meta
+++ b/Assets/00_Content/PhysicMaterials/NoFriction.physicMaterial.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d312ee16874e35b4088b0ee5a4b35bcd
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 13400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/00_Content/Prefabs/Player/Player.prefab
+++ b/Assets/00_Content/Prefabs/Player/Player.prefab
@@ -164,7 +164,7 @@ Rigidbody:
   m_GameObject: {fileID: 2187889529978375777}
   serializedVersion: 2
   m_Mass: 1
-  m_Drag: 10
+  m_Drag: 0
   m_AngularDrag: 0.05
   m_UseGravity: 1
   m_IsKinematic: 0
@@ -429,6 +429,8 @@ MonoBehaviour:
   maxVelocity: 6
   speedMultiplier: 1
   canMove: 1
+  speed: 0
+  actualSpeed: 0
 --- !u!114 &4711298765348120590
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -508,7 +510,7 @@ CapsuleCollider:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2187889530449677917}
-  m_Material: {fileID: 0}
+  m_Material: {fileID: 13400000, guid: d312ee16874e35b4088b0ee5a4b35bcd, type: 2}
   m_IsTrigger: 0
   m_Enabled: 1
   m_Radius: 0.5

--- a/Assets/00_Content/Prefabs/Player/Player.prefab
+++ b/Assets/00_Content/Prefabs/Player/Player.prefab
@@ -429,8 +429,6 @@ MonoBehaviour:
   maxVelocity: 6
   speedMultiplier: 1
   canMove: 1
-  speed: 0
-  actualSpeed: 0
 --- !u!114 &4711298765348120590
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/00_Content/Scripts/Player/PlayerMovement.cs
+++ b/Assets/00_Content/Scripts/Player/PlayerMovement.cs
@@ -15,20 +15,18 @@ namespace Player {
 
 		private Vector2 moveInput;
 		private Vector2 movementDirection;
-		private float speed;
-
-		private Vector3 lastPosition;
-		private float actualSpeed;
+		public float speed;
 
 		public float Speed => speed * speedMultiplier;
 		/// <summary>
-		/// Actual speed of the player (think rigidbody.velocity) clamped to the max speed. Delayed by one FixedUpdate.
+		/// Actual speed of the player (think rigidbody.velocity) clamped to the max speed.
 		/// </summary>
-		public float ActualSpeed => Mathf.Min(actualSpeed, maxVelocity);
+		public float ActualSpeed => Mathf.Min(rigidbody.velocity.magnitude, maxVelocity);
 		public float MaxSpeed => maxVelocity;
 		public Vector2 MoveInput => moveInput;
 		public Vector3 Velocity => new Vector3(movementDirection.x * speed * speedMultiplier, 0f, movementDirection.y * speed * speedMultiplier);
 		public Collider MovementCollider => movementCollider;
+		public Rigidbody Rigidbody => rigidbody;
 		public bool DoMovement { get; set; } = true;
 
 		public float SpeedMultiplier {
@@ -41,8 +39,11 @@ namespace Player {
 			set => canMove = value;
 		}
 
-		private void Start() {
+		private void Awake() {
 			rigidbody = GetComponent<Rigidbody>();
+		}
+
+		private void Start() {
 			mainCamera = Camera.main;
 		}
 
@@ -63,23 +64,18 @@ namespace Player {
 
 			if (DoMovement)
 				ApplyMovement();
-
-			Vector3 currentPosition = transform.position;
-			actualSpeed = (currentPosition - lastPosition).magnitude / Time.deltaTime;
-			lastPosition = currentPosition;
 		}
 
 		private void ApplyMovement() {
-			if (speed == 0 || movementDirection == Vector2.zero) return;
-
-			Vector2 movement2 = movementDirection * (speed * speedMultiplier * Time.deltaTime);
-			if (movement2 == Vector2.zero)
+			if (speed == 0 || speedMultiplier == 0 || movementDirection == Vector2.zero) {
+				rigidbody.velocity = Vector3.zero;
 				return;
+			}
 
+			Vector2 movement2 = movementDirection * (speed * speedMultiplier);
 			Vector3 movement3 = new Vector3(movement2.x, 0, movement2.y);
 
-			rigidbody.MovePosition(transform.position + movement3);
-
+			rigidbody.velocity = movement3;
 			transform.rotation = Quaternion.LookRotation(movement3, Vector3.up);
 		}
 

--- a/Assets/00_Content/Scripts/Player/PlayerMovement.cs
+++ b/Assets/00_Content/Scripts/Player/PlayerMovement.cs
@@ -15,7 +15,7 @@ namespace Player {
 
 		private Vector2 moveInput;
 		private Vector2 movementDirection;
-		public float speed;
+		private float speed;
 
 		public float Speed => speed * speedMultiplier;
 		/// <summary>


### PR DESCRIPTION
**Description**  
Changed player movement to use velocity instead of MovePosition. This fixes the issue of being able to clip through walls.

**List of changes**  
- Player movement now uses velocity to move
- Added a no friction physic material

**Additional context**
The beer barrel also uses MovePosition for its movement. This should also be changed, but as it had problems with collisions I will leave this to be done together with the other barrel fixes.