### PR TITLE
Feature/able to pickup gold after round

### DIFF
--- a/Assets/00_Content/Scripts/Rounds/RoundController.cs
+++ b/Assets/00_Content/Scripts/Rounds/RoundController.cs
@@ -35,7 +35,9 @@ namespace Rounds {
 		private float roundTimer;
 		private int currentRound = 1;
 		private bool isRoundActive = true;
+		private bool isGamePlayActive = true;
 		private bool isTenSecondTimerStarted = false;
+		//ensures the horn has only sounded once at end of round
 
 		public ScalingData CurrentDifficulty =>
 			playerDifficulties[PlayerManager.Instance && PlayerManager.Instance.NumPlayers > 0
@@ -65,11 +67,10 @@ namespace Rounds {
 		}
 
 		private void Update() {
-			if (!isRoundActive) return;
+			if (!isGamePlayActive) return;
 
 			roundTimer += Time.deltaTime;
 
-			
 			if (roundDuration - roundTimer <= 10 && !isTenSecondTimerStarted) {
 				clockTickSound = AudioManager.Instance.PlayEffect(SoundEffect.ClockTick, true);
 				isTenSecondTimerStarted = true;
@@ -79,12 +80,12 @@ namespace Rounds {
 				clockTickSound.Stop();
 				isTenSecondTimerStarted = false;
 				RoundOver();
+				isGamePlayActive = false;
 			}
 		}
 
-		private void RoundOver() {
-			isRoundActive = false;
-			// TODO: Add round over horn SFX
+		private void RoundOver() { 
+			AudioManager.Instance.PlayEffect(SoundEffect.Gameplay_WarHorn);
 
 			StartCoroutine(CoWaitForVikingsLeaving());
 		}
@@ -93,13 +94,13 @@ namespace Rounds {
 			if (VikingController.Instance != null) {
 				VikingController.Instance.CanSpawn = false;
 				VikingController.Instance.LeaveAllVikings();
-				AudioManager.Instance.PlayEffect(SoundEffect.Gameplay_WarHorn);
 
 				while (VikingController.Instance.VikingCount > 0)
 					yield return null;
 			}
 
 			DisableGamePlay();
+			isRoundActive = false;
 			OnRoundOver?.Invoke();
 
 			if (Tavern.Instance != null && Tavern.Instance.Money < requiredMoney) {
@@ -135,12 +136,14 @@ namespace Rounds {
 		}
 
 		private void ShowScoreCard() {
+
 			Transform camTransform = followingCamera.transform;
 			virtualFollowingCamera.transform.SetPositionAndRotation(camTransform.position, camTransform.rotation);
 
 			scoreCard.UpdateScoreCard(currentRound);
 
 			AudioManager.PlayEffectSafe(SoundEffect.Gameplay_RoundWon);
+
 			StartCoroutine(CoMoveToScoreCard());
 		}
 
@@ -168,6 +171,8 @@ namespace Rounds {
 		}
 
 		private void HandleOnNextRound() {
+			isRoundActive = true;
+			isGamePlayActive = true;
 			currentRound++;
 			SendNextDifficulty();
 			roundTimer = 0f;
@@ -196,7 +201,6 @@ namespace Rounds {
 			yield return new WaitForSeconds((float)hideScoreCardTimeline.duration);
 
 			EnableGamePlay();
-			isRoundActive = true;
 		}
 
 		private void HandleOnTablesDestroyed() {

--- a/Assets/00_Content/Scripts/Rounds/RoundController.cs
+++ b/Assets/00_Content/Scripts/Rounds/RoundController.cs
@@ -51,6 +51,7 @@ namespace Rounds {
 		public float RoundTimer => roundTimer;
 		public int RequiredMoney => requiredMoney;
 		public bool IsRoundActive => isRoundActive;
+		public bool IsGamePlayActive => isGamePlayActive;
 
 		private void Start() {
 			scoreCard = Instantiate(scoreCardPrefab);


### PR DESCRIPTION
Closes 

**Description**  
Fixed so that the player can still pick up coins after the round is over while the guests are leaving the bar.

**List of changes**  
- Set up a second bool "isGamePlayActive" so that the player can still move and pick up coins while the time is up and the guests are leaving.
- So isGamePlayActive sets to false as soon as the timer is up, while isRoundActive changes is set to false just before the function DisableGamePlay() runs.