### PR TITLE
Fix viking never leaving when satisfied

### DIFF
--- a/Assets/00_Content/Scripts/Vikings/States/LeavingVikingState.cs
+++ b/Assets/00_Content/Scripts/Vikings/States/LeavingVikingState.cs
@@ -22,6 +22,17 @@ namespace Vikings.States {
 		}
 
 		public override VikingState Update() {
+			maxLeavingTimer += Time.deltaTime;
+
+			if (maxLeavingTimer >= viking.maxLeavingTime) {
+				Debug.LogWarning("Viking took to long to leave the tavern", viking);
+				Object.Instantiate(viking.disappearParticleSystem, viking.transform.position + new Vector3(0, 0.8f, 0), viking.transform.rotation)
+					.gameObject.AddComponent<ParticleCleanup>();
+
+				viking.FinishLeaving();
+				return new NullVikingState(viking);
+			}
+
 			if (isDismounting) {
 				if (!viking.animationDriver.IsSitting) {
 					StartNavigating();
@@ -36,17 +47,6 @@ namespace Vikings.States {
 				return this;
 
 			Debug.Assert(viking.NavMeshAgent.hasPath);
-
-			maxLeavingTimer += Time.deltaTime;
-
-			if (maxLeavingTimer >= viking.maxLeavingTime) {
-				Debug.LogWarning("Viking took to long to leave the tavern", viking);
-				Object.Instantiate(viking.disappearParticleSystem, viking.transform.position + new Vector3(0, 0.8f, 0), viking.transform.rotation)
-					.gameObject.AddComponent<ParticleCleanup>();
-
-				viking.FinishLeaving();
-				return new NullVikingState(viking);
-			}
 
 			if (viking.NavMeshAgent.pathStatus != NavMeshPathStatus.PathComplete) {
 				Debug.LogWarning("Viking has no exit path or is blocked!", viking);

--- a/Assets/00_Content/Scripts/Vikings/States/SatisfiedVikingState.cs
+++ b/Assets/00_Content/Scripts/Vikings/States/SatisfiedVikingState.cs
@@ -44,6 +44,9 @@ namespace Vikings.States {
 		}
 
 		public override void Exit() {
+			viking.animationDriver.Eating = false;
+			viking.animationDriver.Drinking = false;
+
 			if (givenItem != null) {
 				if (satisfiedDesire.shouldThrowItem) {
 					viking.animationDriver.TriggerThrow();
@@ -57,6 +60,9 @@ namespace Vikings.States {
 					givenItem.GetComponent<Rigidbody>().velocity =
 						MathX.RandomDirectionInCone(throwDirection, viking.itemThrowConeHalfAngle) *
 						viking.throwStrength;
+				}
+				else {
+					Object.Destroy(givenItem.gameObject);
 				}
 			}
 		}


### PR DESCRIPTION
Fixes #304 

**Description**  
The viking got stuck because they were waiting for the "leave chair" animation to complete. It never did because the eating/drinking animations have priority.

**List of changes**  
- Clear animator bools when exiting state early
- Made sure the force exit timer always runs
