### PR TITLE
Removed the Refill() event from OnRoundOver

### DIFF
--- a/Assets/00_Content/Scripts/Interactables/Beers/BeerTap.cs
+++ b/Assets/00_Content/Scripts/Interactables/Beers/BeerTap.cs
@@ -48,14 +48,6 @@ namespace Interactables.Beers {
 			fillProgressBar.UpdateProgress(1);
 
 			pourRectTransform = pourProgressBar.GetComponent<RectTransform>();
-
-			if (RoundController.Instance != null)
-				RoundController.Instance.OnRoundOver += Refill;
-		}
-
-		private void OnDestroy() {
-			if (RoundController.Instance != null)
-				RoundController.Instance.OnRoundOver -= Refill;
 		}
 
 		public override bool CanInteract(GameObject player, PickUp item) {


### PR DESCRIPTION
Closes 322

**Description**  
Removed the Refill() event that subscribed to "OnRoundOver" on the RoundController.